### PR TITLE
Add email domain whitelist, furniture type dropdown and form validation

### DIFF
--- a/app-vision.md
+++ b/app-vision.md
@@ -27,7 +27,16 @@ listDate (to show posted 3 days ago etc…)
 JSON example for firebase:
 
 Authentication:
-Google email sign in using firebase, must end in u.northwestern.edu
+Google email sign in using firebase, must end in one of the allowed Northwestern domains:
+
+- @u.northwestern.edu
+- @northwestern.edu
+- @alum.northwestern.edu
+- @nlaw.northwestern.edu
+- @fsm.northwestern.edu
+- @kelloggalumni.northwestern.edu
+- @kellogg.northwestern.edu
+- @law.northwestern.edu
 
 Front-End display needs
 
@@ -48,7 +57,7 @@ Post
 Should have spaces for:
 Image
 Price
-Neighborhood
+Location
 Condition
 User Flows:
 Finding a piece of furniture and messaging seller:
@@ -57,13 +66,12 @@ User scrolls down page
 Uses search bar to narrow down furniture descriptions
 Searches through title, description, condition, location
 Uses filters to narrow down features
-Price range: have boxes for under $20, $20-40, $50 or a slider
-Condition: like new, new, fair, damaged
+Price range: an input for filtering by maximum price
+Condition: New, Like New, Good, Fair, Poor
 Furniture type: searchable dropdown, can check boxes for certain furniture types
 Click on more filters → popup opens in the center of the page with filter types. Can select a filter to see all of the options available.
 Click on a listing → listing expands in a popup with all available information
 See expanded information (description, and contact info)
-Click message seller → button reveals seller contact information
 Click on logo → resets all filters, search query, and sort settings to return to default marketplace page
 
 Listing an item:
@@ -71,7 +79,7 @@ Click list an item
 Fill out listing
 Drop in image
 Type title, description, location
-Select furniture: searchable window where you can select from a list of furniture
+Select furniture type: use drop-down to select from a fixed list of furniture types
 Enter price
 Choose pickup method from dropdown
 Click to save listing → listing is saved to backend → calls the POST listing api

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,7 @@ function App() {
     'Lamp',
     'Sofa',
     'Table',
-    'Other',
+    'Others',
   ];
 
   const filteredListings = listings
@@ -497,6 +497,7 @@ function App() {
           onSubmit={handleAddListing}
           onCancel={() => setShowAddForm(false)}
           isSubmitting={isSubmitting}
+          furnitureTypes={furnitureTypes}
         />
       )}
 

--- a/src/components/AddListingForm.tsx
+++ b/src/components/AddListingForm.tsx
@@ -1,11 +1,30 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import { ALLOWED_EMAIL_DOMAINS } from '../constants/emailDomains';
 import { Listing } from '../types/Listing';
+
+const validateEmail = (email: string): string | null => {
+  if (!email.trim()) {
+    return null;
+  }
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return 'Please enter a valid email address';
+  }
+  const isAllowedDomain = ALLOWED_EMAIL_DOMAINS.some((domain) =>
+    email.toLowerCase().endsWith(domain.toLowerCase()),
+  );
+  if (!isAllowedDomain) {
+    return `Use your Northwestern email in those domains: ${ALLOWED_EMAIL_DOMAINS.join(', ')}`;
+  }
+  return null;
+};
 
 interface AddListingFormProps {
   onSubmit: (listing: Omit<Listing, 'id' | 'userId' | 'createdAt'>) => Promise<void>;
   onCancel: () => void;
   isSubmitting: boolean;
+  furnitureTypes: string[];
 }
 
 const RequiredStar = () => (
@@ -18,6 +37,7 @@ const AddListingForm: React.FC<AddListingFormProps> = ({
   onSubmit,
   onCancel,
   isSubmitting,
+  furnitureTypes,
 }) => {
   const [formData, setFormData] = useState({
     title: '',
@@ -36,6 +56,7 @@ const AddListingForm: React.FC<AddListingFormProps> = ({
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [priceError, setPriceError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -102,6 +123,13 @@ const AddListingForm: React.FC<AddListingFormProps> = ({
       }
       setPriceError(null);
       setFormData((prev) => ({ ...prev, [name]: numValue }));
+    } else if (name === 'sellerContact') {
+      setFormData((prev) => ({
+        ...prev,
+        [name]: value,
+      }));
+      const error = validateEmail(value);
+      setEmailError(error);
     } else {
       setFormData((prev) => ({
         ...prev,
@@ -243,7 +271,16 @@ const AddListingForm: React.FC<AddListingFormProps> = ({
       !formData.location.trim() ||
       !formData.sellerContact.trim();
 
-    if (hasEmptyFields || priceError || formData.price < 0 || formData.price > 9999) {
+    const currentEmailError = validateEmail(formData.sellerContact);
+    setEmailError(currentEmailError);
+
+    if (
+      hasEmptyFields ||
+      priceError ||
+      currentEmailError ||
+      formData.price < 0 ||
+      formData.price > 9999
+    ) {
       return;
     }
 
@@ -501,17 +538,22 @@ const AddListingForm: React.FC<AddListingFormProps> = ({
                   Furniture Type
                   <RequiredStar />
                 </label>
-                <input
+                <select
                   id="furnitureType"
-                  type="text"
                   name="furnitureType"
                   value={formData.furnitureType}
                   onChange={handleChange}
                   onBlur={() => handleBlur('furnitureType')}
                   className="form-input"
-                  placeholder="Chair, Desk, Bookshelf..."
                   style={{ border: errorBorder('furnitureType') }}
-                />
+                >
+                  <option value="">Select a type...</option>
+                  {furnitureTypes.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
                 {isFieldInvalid('furnitureType') && (
                   <p
                     style={{ color: '#dc2626', fontSize: '0.8rem', marginTop: '0.25rem' }}
@@ -533,7 +575,7 @@ const AddListingForm: React.FC<AddListingFormProps> = ({
                   onChange={handleChange}
                   onBlur={() => handleBlur('location')}
                   className="form-input"
-                  placeholder="e.g., 633 Clark St"
+                  placeholder="629 Noyes, Evanston"
                   style={{ border: errorBorder('location') }}
                 />
                 {isFieldInvalid('location') && (
@@ -578,11 +620,21 @@ const AddListingForm: React.FC<AddListingFormProps> = ({
                 onBlur={() => handleBlur('sellerContact')}
                 className="form-input"
                 placeholder="your.email@u.northwestern.edu"
-                style={{ border: errorBorder('sellerContact') }}
+                style={{
+                  border:
+                    emailError || isFieldInvalid('sellerContact')
+                      ? '1.5px solid #dc2626'
+                      : undefined,
+                }}
               />
-              {isFieldInvalid('sellerContact') && (
+              {isFieldInvalid('sellerContact') && !emailError && (
                 <p style={{ color: '#dc2626', fontSize: '0.8rem', marginTop: '0.25rem' }}>
                   Contact email is required
+                </p>
+              )}
+              {emailError && (
+                <p style={{ color: '#dc2626', fontSize: '0.8rem', marginTop: '0.25rem' }}>
+                  {emailError}
                 </p>
               )}
             </div>

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -3,9 +3,8 @@ import '../styles/LoginPage.css';
 import { GoogleAuthProvider, signInWithPopup, signOut } from 'firebase/auth';
 import React, { useState } from 'react';
 
+import { ALLOWED_EMAIL_DOMAINS } from '../constants/emailDomains';
 import { auth } from '../firebase/firebase';
-
-const ALLOWED_DOMAIN = 'u.northwestern.edu';
 
 const LoginPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
@@ -20,9 +19,14 @@ const LoginPage: React.FC = () => {
 
       // Validate email domain
       const email = result.user.email;
-      if (!email || !email.endsWith(`@${ALLOWED_DOMAIN}`)) {
+      const isAllowedDomain = ALLOWED_EMAIL_DOMAINS.some((domain) =>
+        email?.toLowerCase().endsWith(domain.toLowerCase()),
+      );
+      if (!email || !isAllowedDomain) {
         await signOut(auth);
-        setError(`Only ${ALLOWED_DOMAIN} email addresses are allowed.`);
+        setError(
+          `Use your Northwestern email in those domains: ${ALLOWED_EMAIL_DOMAINS.join(', ')}`,
+        );
         setLoading(false);
         return;
       }

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -25,7 +25,7 @@ const LoginPage: React.FC = () => {
       if (!email || !isAllowedDomain) {
         await signOut(auth);
         setError(
-          `Use your Northwestern email in those domains: ${ALLOWED_EMAIL_DOMAINS.join(', ')}`,
+          `Use a Northwestern email address with one of these domains: ${ALLOWED_EMAIL_DOMAINS.join(', ')}`,
         );
         setLoading(false);
         return;

--- a/src/constants/emailDomains.ts
+++ b/src/constants/emailDomains.ts
@@ -1,0 +1,10 @@
+export const ALLOWED_EMAIL_DOMAINS = [
+  '@u.northwestern.edu',
+  '@northwestern.edu',
+  '@alum.northwestern.edu',
+  '@nlaw.northwestern.edu',
+  '@fsm.northwestern.edu',
+  '@kelloggalumni.northwestern.edu',
+  '@kellogg.northwestern.edu',
+  '@law.northwestern.edu',
+];


### PR DESCRIPTION
Introduce a centralized ALLOWED_EMAIL_DOMAINS constant and enforce Northwestern email domains across the app. 
Added src/constants/emailDomains.ts. LoginPage now checks sign-in emails against the whitelist and shows a clearer error message on mismatch. 
AddListingForm now validates sellerContact emails (shows error text and red border), tracks email errors, and prevents submission on invalid domain; it also converts the furniture type input into a select driven by a furnitureTypes prop. 
App.tsx updated to pass furnitureTypes to the form and renamed 'Other' to 'Others'. Updated app-vision.md to list allowed domains and reflect minor UI/UX wording changes (Location, price/condition/filter notes, etc.).